### PR TITLE
CLONE_NEWUSER PoC

### DIFF
--- a/src/firejail/firejail.h
+++ b/src/firejail/firejail.h
@@ -37,11 +37,11 @@ typedef struct bridge_t {
 	char *dev;		// interface device name: bridge or regular ethernet
 	uint32_t ip;		// interface device IP address
 	uint32_t mask;		// interface device mask
-	
+
 	// inside the sandbox
 	char *devsandbox;	// name of the device inside the sandbox
 	uint32_t ipsandbox;	// ipaddress inside the sandbox
-	
+
 	// flags
 	uint8_t arg_ip_none;	// --ip=none
 	uint8_t macvlan;	// set by --net=eth0 (or eth1, ...); reset by --net=br0 (or br1, ...)
@@ -57,7 +57,7 @@ typedef struct config_t {
 	// user data
 	char *username;
 	char *homedir;
-	
+
 	// filesystem
 	ProfileEntry *profile;
 	char *chrootdir;	// chroot directory
@@ -80,11 +80,11 @@ typedef struct config_t {
 	unsigned rlimit_nproc;
 	unsigned rlimit_fsize;
 	unsigned rlimit_sigpending;
-	
+
 	// cpu affinity and control groups
 	uint32_t cpus;
 	char *cgroup;
-	
+
 
 	// command line
 	char *command_line;
@@ -122,7 +122,8 @@ extern int arg_nodbus;		// kill the program if D-Bus is accessed
 extern int arg_nogroups;	// disable supplementary groups
 extern int arg_netfilter;	// enable netfilter
 extern char *arg_netfilter_file;	// netfilter file
-extern int fds[2];
+extern int parent_to_child_fds[2];
+extern int child_to_parent_fds[2];
 
 #define MAX_ARGS 128		// maximum number of command arguments (argc)
 extern char *fullargv[MAX_ARGS];
@@ -291,6 +292,6 @@ void set_cgroup(const char *path);
 void check_output(int argc, char **argv);
 
 // netfilter.c
-void netfilter(const char *fname);
+// void netfilter(const char *fname);
 
 #endif

--- a/src/firejail/main.c
+++ b/src/firejail/main.c
@@ -746,7 +746,7 @@ int main(int argc, char **argv) {
 	close(parent_to_child_fds[0]);
 	close(child_to_parent_fds[1]);
 
-    // notify child that base setup is complete
+	// notify child that base setup is complete
 	notify_other(parent_to_child_fds[1]);
 
 	// wait for child to create new user namespace with CLONE_NEWUSER
@@ -755,15 +755,15 @@ int main(int argc, char **argv) {
 
 	char map_path[500];
 	// update the UID and GID maps in the new child user namespace
-    snprintf(map_path, 500, "/proc/%ld/uid_map",
-      (long) child);
-    update_map("1000 1000 1", map_path);
+	snprintf(map_path, 500, "/proc/%ld/uid_map",
+		(long) child);
+	update_map("1000 1000 1", map_path);
 
-    snprintf(map_path, 500, "/proc/%ld/gid_map",
-      (long) child);
-    update_map("1000 1000 1", map_path);
+	snprintf(map_path, 500, "/proc/%ld/gid_map",
+		(long) child);
+	update_map("1000 1000 1", map_path);
 
-    // notify child that UID/GID mapping is complete
+	// notify child that UID/GID mapping is complete
 	notify_other(parent_to_child_fds[1]);
 	close(parent_to_child_fds[1]);
 

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -82,7 +82,7 @@ int sandbox(void* sandbox_arg) {
 	wait_for_other(parent_to_child_fds[0]);
 
 	if (arg_debug && getpid() == 1)
-			printf("PID namespace installed\n");
+		printf("PID namespace installed\n");
 
 	//****************************
 	// set hostname


### PR DESCRIPTION
This is a PoC for adding `CLONE_NEWUSER` to firejail. This isn't meant to ever be merged..I just wanted to see what obstacles were encountered if one wanted to add support. I first attempted to add support by passing `CLONE_NEWUSER` to the actual clone call. But, the child needs to retain their escalated privilges/access to root in the process' namespace to perform setup actions (such as mount). So, instead, I don't pass any new flag to clone. I let the child perform all the setup they need, drop privileges, and then I detach from the parent user namespace with an `unshare(CLONE_NEWUSER)`. This requries a bit more back and forth communication between the parent/child because the parent still needs to be the one that sets up the uid/gid map for the child after it is detached. But, it seems to at least demonstrate the idea well:

Before:

```
ptoomey3@ubuntu:~$ firejail
Parent pid 33936, child pid 33937
Interface           IP                  Mask                Status
lo                  127.0.0.1           255.0.0.0           UP
eth0                172.16.16.128       255.255.255.0       UP
lxcbr0              10.0.3.1            255.255.255.0       UP

Child process initialized
[ptoomey3@ubuntu ~]$ sudo -s
[sudo] password for ptoomey3:
root@ubuntu:~# whoami
root
```

After:

```
ptoomey3@ubuntu:~$ ./bin/bin/firejail
Parent pid 33770, child pid 33771
Interface           IP                  Mask                Status
lo                  127.0.0.1           255.0.0.0           UP
eth0                172.16.16.128       255.255.255.0       UP
lxcbr0              10.0.3.1            255.255.255.0       UP

Child process initialized
[ptoomey3@ubuntu ~]$ sudo -s
sudo: must be setuid root
```
